### PR TITLE
Magento test framework

### DIFF
--- a/bin/fixperms
+++ b/bin/fixperms
@@ -3,6 +3,7 @@ echo "Correcting filesystem permissions..."
 
 ./bin/cli find media var -type f -exec chmod u+w {} \;
 ./bin/cli find media var -type d -exec chmod u+w {} \;
+./bin/cli find /var/www/.composer -type d -exec chmod u+w {} \;
 ./bin/cli chmod u+x mage
 
 echo "Filesystem permissions corrected."

--- a/bin/fixperms
+++ b/bin/fixperms
@@ -6,5 +6,6 @@ echo "Correcting filesystem permissions..."
 ./bin/cli find /var/www/.composer -type d -exec chmod u+w {} \;
 ./bin/cli chmod 777 /sock/docker.sock
 ./bin/cli chmod u+x mage
+./bin/cli chmod -R 777 skin js
 
 echo "Filesystem permissions corrected."

--- a/bin/fixperms
+++ b/bin/fixperms
@@ -4,6 +4,7 @@ echo "Correcting filesystem permissions..."
 ./bin/cli find media var -type f -exec chmod u+w {} \;
 ./bin/cli find media var -type d -exec chmod u+w {} \;
 ./bin/cli find /var/www/.composer -type d -exec chmod u+w {} \;
+./bin/cli chmod 777 /sock/docker.sock
 ./bin/cli chmod u+x mage
 
 echo "Filesystem permissions corrected."

--- a/bin/seleniumserver
+++ b/bin/seleniumserver
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+./bin/cli bash -c "java -jar /var/www/plugins/dev/Rakuten/tests/vendor/se/selenium-server-standalone/bin/selenium-server-standalone.jar -role hub -host 172.18.0.4 &> /var/www/html/output.log & java -jar /var/www/plugins/dev/Rakuten/tests/vendor/se/selenium-server-standalone/bin/selenium-server-standalone.jar -role node -hub http://172.18.0.4:4444/grid/register &> /var/www/html/node.log"

--- a/bin/test
+++ b/bin/test
@@ -1,2 +1,7 @@
 #!/bin/bash
+
+./bin/cli mv /var/www/html/app/etc/local.xml /tmp/local.xml
+./bin/cli cp /var/www/plugins/dev/Rakuten/tests/etc/local.xml /var/www/html/app/etc/local.xml
 ./bin/cli bash -c "cd ../plugins/dev/Rakuten/tests/ && sleep 1 && ./vendor/bin/behat"
+./bin/cli rm /var/www/html/app/etc/local.xml
+./bin/cli mv /tmp/local.xml /var/www/html/app/etc/local.xml

--- a/bin/test
+++ b/bin/test
@@ -1,0 +1,2 @@
+#!/bin/bash
+./bin/cli bash -c "cd ../plugins/dev/Rakuten/tests/ && sleep 1 && ./vendor/bin/behat"

--- a/bin/testsetup
+++ b/bin/testsetup
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+./bin/cli bash -c "cd /var/www/plugins/dev/Rakuten/tests/ && composer update"
+./bin/cli bash -c "java -jar /var/www/plugins/dev/Rakuten/tests/vendor/se/selenium-server-standalone/bin/selenium-server-standalone.jar -role hub &> /var/www/html/output.log & java -jar /var/www/plugins/dev/Rakuten/tests/vendor/se/selenium-server-standalone/bin/selenium-server-standalone.jar -role node -hub http://172.18.0.3:4444/grid/register &> /var/www/html/node.log"

--- a/bin/testsetup
+++ b/bin/testsetup
@@ -1,4 +1,38 @@
 #!/bin/bash
 
+docker-compose exec db mysql -h db -u magento -pmagento -e 'drop database magento_test'
+docker-compose exec db mysql -h db -u magento -pmagento -e 'create database magento_test'
+
+# Download magento sample database
+curl https://raw.githubusercontent.com/bluec/compressed-magento-sample-data/1.9.2.4/compressed-magento-sample-data-1.9.2.4.tgz -o /tmp/compressed-magento-sample-data-1.9.2.4.tgz
+tar -xf /tmp/compressed-magento-sample-data-1.9.2.4.tgz -C /tmp/
+mkdir -p ./src/media/catalog
+cp -vnpr /tmp/magento-sample-data-1.9.2.4/media/* ./src/media/
+cp -vnpr /tmp/magento-sample-data-1.9.2.4/skin/* ./src/skin/
+docker-compose exec -T phpfpm mysql -h db -u magento -pmagento magento_test < /tmp/magento-sample-data-1.9.2.4/magento_sample_data_for_1.9.2.4.sql
+
+# Use test environment local.xml
+./bin/cli mv /var/www/html/app/etc/local.xml /tmp/local.xml
+./bin/cli cp /var/www/plugins/dev/Rakuten/tests/etc/local.xml /var/www/html/app/etc/local.xml
+
+# Setup magento
+./bin/magerun index:reindex:all
+./bin/magerun config:set web/secure/base_url $MAGENTO1_DOMAIN_URL
+./bin/magerun config:set web/unsecure/base_url $MAGENTO1_DOMAIN_URL
+./bin/magerun config:set currency/options/base BRL
+./bin/magerun config:set currency/options/default BRL
+./bin/magerun config:set currency/options/allow USD,EUR,BRL
+./bin/magerun admin:user:create admin admin@example.com password admin doe
+./bin/magerun customer:create -n customer@example.com password customer doe
+./bin/magerun cache:disable
+
+# Create default admin and customer users
+./bin/magerun admin:user:create admin admin@example.com password admin doe
+./bin/magerun customer:create -n customer@example.com password customer doe
+
+# Rollback to normal local.xml
+./bin/cli rm /var/www/html/app/etc/local.xml
+./bin/cli mv /tmp/local.xml /var/www/html/app/etc/local.xml
+
+# Update composer for tests, ensuring dependencies are installed
 ./bin/cli bash -c "cd /var/www/plugins/dev/Rakuten/tests/ && composer update"
-./bin/cli bash -c "java -jar /var/www/plugins/dev/Rakuten/tests/vendor/se/selenium-server-standalone/bin/selenium-server-standalone.jar -role hub &> /var/www/html/output.log & java -jar /var/www/plugins/dev/Rakuten/tests/vendor/se/selenium-server-standalone/bin/selenium-server-standalone.jar -role node -hub http://172.18.0.3:4444/grid/register &> /var/www/html/node.log"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     container_name: ${PROJECT_NAME}-static
     restart: always
     ports:
-      - "${LOCALHOST_HTTP_PORT:-80}:8000"
+      - "${LOCALHOST_HTTP_PORT:-80}:80"
       - "${LOCALHOST_HTTPS_PORT:-443}:443"
     links:
       - db
@@ -23,7 +23,7 @@ services:
       - sockdata:/sock
 
   phpfpm:
-    image: markoshust/magento-php:5.6-fpm
+    build: images/php-fpm
     links:
       - db
     restart: always

--- a/images/nginx/Dockerfile
+++ b/images/nginx/Dockerfile
@@ -1,11 +1,8 @@
 FROM nginx:1.13
 MAINTAINER Mark Shust <mark@shust.com>
 
-RUN groupadd -g 1000 app \
- && useradd -g 1000 -u 1000 -d /var/www -s /bin/bash app
 RUN touch /var/run/nginx.pid
 RUN mkdir /sock
-RUN chown -R app:app /var/cache/nginx/ /var/run/nginx.pid /sock
 
 COPY ./conf/nginx.conf /etc/nginx/
 COPY ./conf/default.conf /etc/nginx/conf.d/

--- a/images/nginx/Dockerfile
+++ b/images/nginx/Dockerfile
@@ -1,3 +1,17 @@
-FROM markoshust/magento-nginx:1.13
+FROM nginx:1.13
+MAINTAINER Mark Shust <mark@shust.com>
+
+RUN groupadd -g 1000 app \
+ && useradd -g 1000 -u 1000 -d /var/www -s /bin/bash app
+RUN touch /var/run/nginx.pid
+RUN mkdir /sock
+RUN chown -R app:app /var/cache/nginx/ /var/run/nginx.pid /sock
+
+COPY ./conf/nginx.conf /etc/nginx/
+COPY ./conf/default.conf /etc/nginx/conf.d/
+
+VOLUME /var/www
+
+WORKDIR /var/www/html
 
 COPY ./conf/default.conf /etc/nginx/conf.d/

--- a/images/nginx/conf/default.conf
+++ b/images/nginx/conf/default.conf
@@ -3,7 +3,7 @@ upstream fastcgi_backend {
 }
 
 server {
-  listen 8000;
+  listen 80;
   server_name localhost;
 
   set $MAGE_ROOT /var/www/html;

--- a/images/nginx/conf/nginx.conf
+++ b/images/nginx/conf/nginx.conf
@@ -1,0 +1,32 @@
+# let's assume dual-core machine
+worker_processes 2;
+
+error_log /var/log/nginx/error.log debug;
+pid /var/run/nginx.pid;
+
+events {
+  # this should be equal to value of "ulimit -n"
+  # reference: https://www.digitalocean.com/community/tutorials/how-to-optimize-nginx-configuration
+  worker_connections 1048576;
+}
+
+http {
+  include /etc/nginx/mime.types;
+  default_type application/octet-stream;
+
+  log_format main
+    '$remote_addr - $remote_user [$time_local] "$request" '
+    '$status $body_bytes_sent "$http_referer" '
+    '"$http_user_agent" "$http_x_forwarded_for"';
+
+  access_log /var/log/nginx/access.log main;
+
+  sendfile on;
+  #tcp_nopush on;
+
+  keepalive_timeout 65;
+
+  #gzip on;
+
+  include /etc/nginx/conf.d/*.conf;
+}

--- a/images/php-fpm/Dockerfile
+++ b/images/php-fpm/Dockerfile
@@ -36,9 +36,6 @@ RUN pecl channel-update pecl.php.net \
 RUN curl -sS https://getcomposer.org/installer | \
   php -- --install-dir=/usr/local/bin --filename=composer
 
-RUN groupadd -g 1000 app \
- && useradd -g 1000 -u 1000 -d /var/www -s /bin/bash app
-
 RUN printf '* *\t* * *\tapp\t%s/usr/local/bin/php /var/www/html/cron.php\n#\n' >> /etc/crontab
 
 COPY conf/www.conf /usr/local/etc/php-fpm.d/
@@ -54,27 +51,28 @@ WORKDIR /var/www/html
 
 EXPOSE 9001
 
-USER root
-
 # Install Java.
 RUN mkdir /usr/share/man/man1/
 RUN mkdir /var/www/.cache
 
 RUN \
   apt-get update && \
-  apt-get install -y software-properties-common iceweasel xvfb wget && \
+  apt-get install -y software-properties-common xvfb wget sudo gnupg && \
   add-apt-repository ppa:openjdk-r/ppa && \
   apt-get install -y openjdk-8-jdk && \
 rm -rf /var/lib/apt/lists/*
 
 ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-amd64
 
-# Geckodriver
-RUN wget https://github.com/mozilla/geckodriver/releases/download/v0.16.1/geckodriver-v0.16.1-linux64.tar.gz && \
-    sh -c 'tar -x geckodriver -zf geckodriver-v0.16.1-linux64.tar.gz -O > /usr/bin/geckodriver' && \
-    chmod +x /usr/bin/geckodriver && \
-    rm geckodriver-v0.16.1-linux64.tar.gz
+RUN apt-get update && \
+    apt-get install -yq wget --no-install-recommends && \
+    wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - && \
+    sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' && \
+    apt-get update && \
+    apt-get install -y chromedriver google-chrome-unstable fonts-ipafont-gothic fonts-wqy-zenhei fonts-thai-tlwg fonts-kacst ttf-freefont libgconf-2-4 --no-install-recommends
 
-RUN groupadd docker && usermod -aG docker app
+RUN mkdir /tmp/.X11-unix && \
+    chmod 1777 /tmp/.X11-unix && \
+    chown root /tmp/.X11-unix/
 
 ENTRYPOINT ["docker-php-entrypoint", "-R"]

--- a/images/php-fpm/Dockerfile
+++ b/images/php-fpm/Dockerfile
@@ -72,4 +72,6 @@ RUN apt-get update && \
     apt-get update && \
     apt-get install -y chromedriver google-chrome-unstable fonts-ipafont-gothic fonts-wqy-zenhei fonts-thai-tlwg fonts-kacst ttf-freefont libgconf-2-4 --no-install-recommends
 
+RUN apt-get install ifconfig
+
 ENTRYPOINT ["docker-php-entrypoint", "-R"]

--- a/images/php-fpm/Dockerfile
+++ b/images/php-fpm/Dockerfile
@@ -64,15 +64,12 @@ rm -rf /var/lib/apt/lists/*
 
 ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-amd64
 
+# Chrome and chromedriver
 RUN apt-get update && \
     apt-get install -yq wget --no-install-recommends && \
     wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - && \
     sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' && \
     apt-get update && \
     apt-get install -y chromedriver google-chrome-unstable fonts-ipafont-gothic fonts-wqy-zenhei fonts-thai-tlwg fonts-kacst ttf-freefont libgconf-2-4 --no-install-recommends
-
-RUN mkdir /tmp/.X11-unix && \
-    chmod 1777 /tmp/.X11-unix && \
-    chown root /tmp/.X11-unix/
 
 ENTRYPOINT ["docker-php-entrypoint", "-R"]

--- a/images/php-fpm/Dockerfile
+++ b/images/php-fpm/Dockerfile
@@ -1,0 +1,80 @@
+FROM php:5.6-fpm
+
+RUN apt-get update && apt-get install -y \
+  cron \
+  git \
+  libfreetype6-dev \
+  libicu-dev \
+  libjpeg62-turbo-dev \
+  libmcrypt-dev \
+  libpng-dev \
+  libxslt1-dev \
+  mysql-client \
+  vim \
+  zip
+
+RUN docker-php-ext-configure \
+  gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/
+
+RUN docker-php-ext-install \
+  bcmath \
+  gd \
+  intl \
+  mbstring \
+  mcrypt \
+  opcache \
+  pdo_mysql \
+  soap \
+  xsl \
+  zip
+
+RUN pecl channel-update pecl.php.net \
+  && pecl install xdebug-2.5.5 \
+  && docker-php-ext-enable xdebug \
+  && sed -i -e 's/^zend_extension/\;zend_extension/g' /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
+
+RUN curl -sS https://getcomposer.org/installer | \
+  php -- --install-dir=/usr/local/bin --filename=composer
+
+RUN groupadd -g 1000 app \
+ && useradd -g 1000 -u 1000 -d /var/www -s /bin/bash app
+
+RUN printf '* *\t* * *\tapp\t%s/usr/local/bin/php /var/www/html/cron.php\n#\n' >> /etc/crontab
+
+COPY conf/www.conf /usr/local/etc/php-fpm.d/
+COPY conf/php.ini /usr/local/etc/php/
+COPY conf/php-fpm.conf /usr/local/etc/
+COPY bin/cronstart /usr/local/bin/
+
+RUN mkdir /sock
+
+VOLUME /var/www
+
+WORKDIR /var/www/html
+
+EXPOSE 9001
+
+USER root
+
+# Install Java.
+RUN mkdir /usr/share/man/man1/
+RUN mkdir /var/www/.cache
+
+RUN \
+  apt-get update && \
+  apt-get install -y software-properties-common iceweasel xvfb wget && \
+  add-apt-repository ppa:openjdk-r/ppa && \
+  apt-get install -y openjdk-8-jdk && \
+rm -rf /var/lib/apt/lists/*
+
+ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-amd64
+
+# Geckodriver
+RUN wget https://github.com/mozilla/geckodriver/releases/download/v0.16.1/geckodriver-v0.16.1-linux64.tar.gz && \
+    sh -c 'tar -x geckodriver -zf geckodriver-v0.16.1-linux64.tar.gz -O > /usr/bin/geckodriver' && \
+    chmod +x /usr/bin/geckodriver && \
+    rm geckodriver-v0.16.1-linux64.tar.gz
+
+RUN groupadd docker && usermod -aG docker app
+
+ENTRYPOINT ["docker-php-entrypoint", "-R"]

--- a/images/php-fpm/bin/cronstart
+++ b/images/php-fpm/bin/cronstart
@@ -1,0 +1,4 @@
+#!/bin/bash
+service cron start
+
+/usr/bin/crontab

--- a/images/php-fpm/conf/php-fpm.conf
+++ b/images/php-fpm/conf/php-fpm.conf
@@ -1,0 +1,29 @@
+; This file was initially adapated from the output of: (on PHP 5.6)
+;   grep -vE '^;|^ *$' /usr/local/etc/php-fpm.conf.default
+
+[global]
+
+error_log = /proc/self/fd/2
+daemonize = no
+
+[www]
+
+; if we send this to /proc/self/fd/1, it never appears
+access.log = /proc/self/fd/2
+
+user = root
+
+listen = /sock/docker.sock
+listen.owner = root
+listen.mode = 0660
+
+pm = dynamic
+pm.max_children = 10
+pm.start_servers = 4
+pm.min_spare_servers = 2
+pm.max_spare_servers = 6
+
+clear_env = no
+
+; Ensure worker stdout and stderr are sent to the main error log.
+catch_workers_output = yes

--- a/images/php-fpm/conf/php.ini
+++ b/images/php-fpm/conf/php.ini
@@ -1,0 +1,12 @@
+memory_limit = 2G
+max_execution_time = 1800
+zlib.output_compression = On
+cgi.fix_pathinfo = 0
+date.timezone = UTC
+
+xdebug.idekey = PHPSTORM
+xdebug.remote_autostart = 1
+xdebug.remote_connect_back = 0
+xdebug.remote_enable = 1
+xdebug.remote_host = 10.254.254.254
+xdebug.remote_port = 9001

--- a/images/php-fpm/conf/www.conf
+++ b/images/php-fpm/conf/www.conf
@@ -1,0 +1,412 @@
+; Start a new pool named 'www'.
+; the variable $pool can we used in any directive and will be replaced by the
+; pool name ('www' here)
+[www]
+
+; Per pool prefix
+; It only applies on the following directives:
+; - 'access.log'
+; - 'slowlog'
+; - 'listen' (unixsocket)
+; - 'chroot'
+; - 'chdir'
+; - 'php_values'
+; - 'php_admin_values'
+; When not set, the global prefix (or NONE) applies instead.
+; Note: This directive can also be relative to the global prefix.
+; Default Value: none
+;prefix = /path/to/pools/$pool
+
+; Unix user/group of processes
+; Note: The user is mandatory. If the group is not set, the default user's group
+;       will be used.
+user = root
+
+; The address on which to accept FastCGI requests.
+; Valid syntaxes are:
+;   'ip.add.re.ss:port'    - to listen on a TCP socket to a specific IPv4 address on
+;                            a specific port;
+;   '[ip:6:addr:ess]:port' - to listen on a TCP socket to a specific IPv6 address on
+;                            a specific port;
+;   'port'                 - to listen on a TCP socket to all addresses
+;                            (IPv6 and IPv4-mapped) on a specific port;
+;   '/path/to/unix/socket' - to listen on a unix socket.
+; Note: This value is mandatory.
+listen = 127.0.0.1:9000
+
+; Set listen(2) backlog.
+; Default Value: 511 (-1 on FreeBSD and OpenBSD)
+;listen.backlog = 511
+
+; Set permissions for unix socket, if one is used. In Linux, read/write
+; permissions must be set in order to allow connections from a web server. Many
+; BSD-derived systems allow connections regardless of permissions.
+; Default Values: user and group are set as the running user
+;                 mode is set to 0660
+;listen.owner = www-data
+;listen.group = www-data
+;listen.mode = 0660
+; When POSIX Access Control Lists are supported you can set them using
+; these options, value is a comma separated list of user/group names.
+; When set, listen.owner and listen.group are ignored
+;listen.acl_users =
+;listen.acl_groups =
+
+; List of addresses (IPv4/IPv6) of FastCGI clients which are allowed to connect.
+; Equivalent to the FCGI_WEB_SERVER_ADDRS environment variable in the original
+; PHP FCGI (5.2.2+). Makes sense only with a tcp listening socket. Each address
+; must be separated by a comma. If this value is left blank, connections will be
+; accepted from any ip address.
+; Default Value: any
+;listen.allowed_clients = 127.0.0.1
+
+; Specify the nice(2) priority to apply to the pool processes (only if set)
+; The value can vary from -19 (highest priority) to 20 (lower priority)
+; Note: - It will only work if the FPM master process is launched as root
+;       - The pool processes will inherit the master process priority
+;         unless it specified otherwise
+; Default Value: no set
+; process.priority = -19
+
+; Choose how the process manager will control the number of child processes.
+; Possible Values:
+;   static  - a fixed number (pm.max_children) of child processes;
+;   dynamic - the number of child processes are set dynamically based on the
+;             following directives. With this process management, there will be
+;             always at least 1 children.
+;             pm.max_children      - the maximum number of children that can
+;                                    be alive at the same time.
+;             pm.start_servers     - the number of children created on startup.
+;             pm.min_spare_servers - the minimum number of children in 'idle'
+;                                    state (waiting to process). If the number
+;                                    of 'idle' processes is less than this
+;                                    number then some children will be created.
+;             pm.max_spare_servers - the maximum number of children in 'idle'
+;                                    state (waiting to process). If the number
+;                                    of 'idle' processes is greater than this
+;                                    number then some children will be killed.
+;  ondemand - no children are created at startup. Children will be forked when
+;             new requests will connect. The following parameter are used:
+;             pm.max_children           - the maximum number of children that
+;                                         can be alive at the same time.
+;             pm.process_idle_timeout   - The number of seconds after which
+;                                         an idle process will be killed.
+; Note: This value is mandatory.
+pm = dynamic
+
+; The number of child processes to be created when pm is set to 'static' and the
+; maximum number of child processes when pm is set to 'dynamic' or 'ondemand'.
+; This value sets the limit on the number of simultaneous requests that will be
+; served. Equivalent to the ApacheMaxClients directive with mpm_prefork.
+; Equivalent to the PHP_FCGI_CHILDREN environment variable in the original PHP
+; CGI. The below defaults are based on a server without much resources. Don't
+; forget to tweak pm.* to fit your needs.
+; Note: Used when pm is set to 'static', 'dynamic' or 'ondemand'
+; Note: This value is mandatory.
+pm.max_children = 5
+
+; The number of child processes created on startup.
+; Note: Used only when pm is set to 'dynamic'
+; Default Value: min_spare_servers + (max_spare_servers - min_spare_servers) / 2
+pm.start_servers = 2
+
+; The desired minimum number of idle server processes.
+; Note: Used only when pm is set to 'dynamic'
+; Note: Mandatory when pm is set to 'dynamic'
+pm.min_spare_servers = 1
+
+; The desired maximum number of idle server processes.
+; Note: Used only when pm is set to 'dynamic'
+; Note: Mandatory when pm is set to 'dynamic'
+pm.max_spare_servers = 3
+
+; The number of seconds after which an idle process will be killed.
+; Note: Used only when pm is set to 'ondemand'
+; Default Value: 10s
+;pm.process_idle_timeout = 10s;
+
+; The number of requests each child process should execute before respawning.
+; This can be useful to work around memory leaks in 3rd party libraries. For
+; endless request processing specify '0'. Equivalent to PHP_FCGI_MAX_REQUESTS.
+; Default Value: 0
+;pm.max_requests = 500
+
+; The URI to view the FPM status page. If this value is not set, no URI will be
+; recognized as a status page. It shows the following informations:
+;   pool                 - the name of the pool;
+;   process manager      - static, dynamic or ondemand;
+;   start time           - the date and time FPM has started;
+;   start since          - number of seconds since FPM has started;
+;   accepted conn        - the number of request accepted by the pool;
+;   listen queue         - the number of request in the queue of pending
+;                          connections (see backlog in listen(2));
+;   max listen queue     - the maximum number of requests in the queue
+;                          of pending connections since FPM has started;
+;   listen queue len     - the size of the socket queue of pending connections;
+;   idle processes       - the number of idle processes;
+;   active processes     - the number of active processes;
+;   total processes      - the number of idle + active processes;
+;   max active processes - the maximum number of active processes since FPM
+;                          has started;
+;   max children reached - number of times, the process limit has been reached,
+;                          when pm tries to start more children (works only for
+;                          pm 'dynamic' and 'ondemand');
+; Value are updated in real time.
+; Example output:
+;   pool:                 www
+;   process manager:      static
+;   start time:           01/Jul/2011:17:53:49 +0200
+;   start since:          62636
+;   accepted conn:        190460
+;   listen queue:         0
+;   max listen queue:     1
+;   listen queue len:     42
+;   idle processes:       4
+;   active processes:     11
+;   total processes:      15
+;   max active processes: 12
+;   max children reached: 0
+;
+; By default the status page output is formatted as text/plain. Passing either
+; 'html', 'xml' or 'json' in the query string will return the corresponding
+; output syntax. Example:
+;   http://www.foo.bar/status
+;   http://www.foo.bar/status?json
+;   http://www.foo.bar/status?html
+;   http://www.foo.bar/status?xml
+;
+; By default the status page only outputs short status. Passing 'full' in the
+; query string will also return status for each pool process.
+; Example:
+;   http://www.foo.bar/status?full
+;   http://www.foo.bar/status?json&full
+;   http://www.foo.bar/status?html&full
+;   http://www.foo.bar/status?xml&full
+; The Full status returns for each process:
+;   pid                  - the PID of the process;
+;   state                - the state of the process (Idle, Running, ...);
+;   start time           - the date and time the process has started;
+;   start since          - the number of seconds since the process has started;
+;   requests             - the number of requests the process has served;
+;   request duration     - the duration in µs of the requests;
+;   request method       - the request method (GET, POST, ...);
+;   request URI          - the request URI with the query string;
+;   content length       - the content length of the request (only with POST);
+;   user                 - the user (PHP_AUTH_USER) (or '-' if not set);
+;   script               - the main script called (or '-' if not set);
+;   last request cpu     - the %cpu the last request consumed
+;                          it's always 0 if the process is not in Idle state
+;                          because CPU calculation is done when the request
+;                          processing has terminated;
+;   last request memory  - the max amount of memory the last request consumed
+;                          it's always 0 if the process is not in Idle state
+;                          because memory calculation is done when the request
+;                          processing has terminated;
+; If the process is in Idle state, then informations are related to the
+; last request the process has served. Otherwise informations are related to
+; the current request being served.
+; Example output:
+;   ************************
+;   pid:                  31330
+;   state:                Running
+;   start time:           01/Jul/2011:17:53:49 +0200
+;   start since:          63087
+;   requests:             12808
+;   request duration:     1250261
+;   request method:       GET
+;   request URI:          /test_mem.php?N=10000
+;   content length:       0
+;   user:                 -
+;   script:               /home/fat/web/docs/php/test_mem.php
+;   last request cpu:     0.00
+;   last request memory:  0
+;
+; Note: There is a real-time FPM status monitoring sample web page available
+;       It's available in: /usr/local/share/php/fpm/status.html
+;
+; Note: The value must start with a leading slash (/). The value can be
+;       anything, but it may not be a good idea to use the .php extension or it
+;       may conflict with a real PHP file.
+; Default Value: not set
+;pm.status_path = /status
+
+; The ping URI to call the monitoring page of FPM. If this value is not set, no
+; URI will be recognized as a ping page. This could be used to test from outside
+; that FPM is alive and responding, or to
+; - create a graph of FPM availability (rrd or such);
+; - remove a server from a group if it is not responding (load balancing);
+; - trigger alerts for the operating team (24/7).
+; Note: The value must start with a leading slash (/). The value can be
+;       anything, but it may not be a good idea to use the .php extension or it
+;       may conflict with a real PHP file.
+; Default Value: not set
+;ping.path = /ping
+
+; This directive may be used to customize the response of a ping request. The
+; response is formatted as text/plain with a 200 response code.
+; Default Value: pong
+;ping.response = pong
+
+; The access log file
+; Default: not set
+;access.log = log/$pool.access.log
+
+; The access log format.
+; The following syntax is allowed
+;  %%: the '%' character
+;  %C: %CPU used by the request
+;      it can accept the following format:
+;      - %{user}C for user CPU only
+;      - %{system}C for system CPU only
+;      - %{total}C  for user + system CPU (default)
+;  %d: time taken to serve the request
+;      it can accept the following format:
+;      - %{seconds}d (default)
+;      - %{miliseconds}d
+;      - %{mili}d
+;      - %{microseconds}d
+;      - %{micro}d
+;  %e: an environment variable (same as $_ENV or $_SERVER)
+;      it must be associated with embraces to specify the name of the env
+;      variable. Some exemples:
+;      - server specifics like: %{REQUEST_METHOD}e or %{SERVER_PROTOCOL}e
+;      - HTTP headers like: %{HTTP_HOST}e or %{HTTP_USER_AGENT}e
+;  %f: script filename
+;  %l: content-length of the request (for POST request only)
+;  %m: request method
+;  %M: peak of memory allocated by PHP
+;      it can accept the following format:
+;      - %{bytes}M (default)
+;      - %{kilobytes}M
+;      - %{kilo}M
+;      - %{megabytes}M
+;      - %{mega}M
+;  %n: pool name
+;  %o: output header
+;      it must be associated with embraces to specify the name of the header:
+;      - %{Content-Type}o
+;      - %{X-Powered-By}o
+;      - %{Transfert-Encoding}o
+;      - ....
+;  %p: PID of the child that serviced the request
+;  %P: PID of the parent of the child that serviced the request
+;  %q: the query string
+;  %Q: the '?' character if query string exists
+;  %r: the request URI (without the query string, see %q and %Q)
+;  %R: remote IP address
+;  %s: status (response code)
+;  %t: server time the request was received
+;      it can accept a strftime(3) format:
+;      %d/%b/%Y:%H:%M:%S %z (default)
+;      The strftime(3) format must be encapsuled in a %{<strftime_format>}t tag
+;      e.g. for a ISO8601 formatted timestring, use: %{%Y-%m-%dT%H:%M:%S%z}t
+;  %T: time the log has been written (the request has finished)
+;      it can accept a strftime(3) format:
+;      %d/%b/%Y:%H:%M:%S %z (default)
+;      The strftime(3) format must be encapsuled in a %{<strftime_format>}t tag
+;      e.g. for a ISO8601 formatted timestring, use: %{%Y-%m-%dT%H:%M:%S%z}t
+;  %u: remote user
+;
+; Default: "%R - %u %t \"%m %r\" %s"
+;access.format = "%R - %u %t \"%m %r%Q%q\" %s %f %{mili}d %{kilo}M %C%%"
+
+; The log file for slow requests
+; Default Value: not set
+; Note: slowlog is mandatory if request_slowlog_timeout is set
+;slowlog = log/$pool.log.slow
+
+; The timeout for serving a single request after which a PHP backtrace will be
+; dumped to the 'slowlog' file. A value of '0s' means 'off'.
+; Available units: s(econds)(default), m(inutes), h(ours), or d(ays)
+; Default Value: 0
+;request_slowlog_timeout = 0
+
+; The timeout for serving a single request after which the worker process will
+; be killed. This option should be used when the 'max_execution_time' ini option
+; does not stop script execution for some reason. A value of '0' means 'off'.
+; Available units: s(econds)(default), m(inutes), h(ours), or d(ays)
+; Default Value: 0
+;request_terminate_timeout = 0
+
+; Set open file descriptor rlimit.
+; Default Value: system defined value
+;rlimit_files = 1024
+
+; Set max core size rlimit.
+; Possible Values: 'unlimited' or an integer greater or equal to 0
+; Default Value: system defined value
+;rlimit_core = 0
+
+; Chroot to this directory at the start. This value must be defined as an
+; absolute path. When this value is not set, chroot is not used.
+; Note: you can prefix with '$prefix' to chroot to the pool prefix or one
+; of its subdirectories. If the pool prefix is not set, the global prefix
+; will be used instead.
+; Note: chrooting is a great security feature and should be used whenever
+;       possible. However, all PHP paths will be relative to the chroot
+;       (error_log, sessions.save_path, ...).
+; Default Value: not set
+;chroot =
+
+; Chdir to this directory at the start.
+; Note: relative path can be used.
+; Default Value: current directory or / when chroot
+;chdir = /var/www
+
+; Redirect worker stdout and stderr into main error log. If not set, stdout and
+; stderr will be redirected to /dev/null according to FastCGI specs.
+; Note: on highloaded environement, this can cause some delay in the page
+; process time (several ms).
+; Default Value: no
+;catch_workers_output = yes
+
+; Clear environment in FPM workers
+; Prevents arbitrary environment variables from reaching FPM worker processes
+; by clearing the environment in workers before env vars specified in this
+; pool configuration are added.
+; Setting to "no" will make all environment variables available to PHP code
+; via getenv(), $_ENV and $_SERVER.
+; Default Value: yes
+;clear_env = no
+
+; Limits the extensions of the main script FPM will allow to parse. This can
+; prevent configuration mistakes on the web server side. You should only limit
+; FPM to .php extensions to prevent malicious users to use other extensions to
+; exectute php code.
+; Note: set an empty value to allow all extensions.
+; Default Value: .php
+;security.limit_extensions = .php .php3 .php4 .php5 .php7
+
+; Pass environment variables like LD_LIBRARY_PATH. All $VARIABLEs are taken from
+; the current environment.
+; Default Value: clean env
+;env[HOSTNAME] = $HOSTNAME
+;env[PATH] = /usr/local/bin:/usr/bin:/bin
+;env[TMP] = /tmp
+;env[TMPDIR] = /tmp
+;env[TEMP] = /tmp
+
+; Additional php.ini defines, specific to this pool of workers. These settings
+; overwrite the values previously defined in the php.ini. The directives are the
+; same as the PHP SAPI:
+;   php_value/php_flag             - you can set classic ini defines which can
+;                                    be overwritten from PHP call 'ini_set'.
+;   php_admin_value/php_admin_flag - these directives won't be overwritten by
+;                                     PHP call 'ini_set'
+; For php_*flag, valid values are on, off, 1, 0, true, false, yes or no.
+
+; Defining 'extension' will load the corresponding shared extension from
+; extension_dir. Defining 'disable_functions' or 'disable_classes' will not
+; overwrite previously defined php.ini values, but will append the new value
+; instead.
+
+; Note: path INI options can be relative and will be expanded with the prefix
+; (pool, global or /usr/local)
+
+; Default Value: nothing is defined by default except the values in php.ini and
+;                specified at startup with the -d argument
+;php_admin_value[sendmail_path] = /usr/sbin/sendmail -t -i -f www@my.domain.com
+;php_flag[display_errors] = off
+;php_admin_value[error_log] = /var/log/fpm-php.www.log
+;php_admin_flag[log_errors] = on
+;php_admin_value[memory_limit] = 32M

--- a/images/php-fpm/conf/www.conf
+++ b/images/php-fpm/conf/www.conf
@@ -20,7 +20,7 @@
 ; Unix user/group of processes
 ; Note: The user is mandatory. If the group is not set, the default user's group
 ;       will be used.
-user = root
+user =  root
 
 ; The address on which to accept FastCGI requests.
 ; Valid syntaxes are:


### PR DESCRIPTION
This PR aims to add the infrastructure to allow Selenium testing using the container.

To do this, some changes were made to the Dockerfile:

- **Build images locally**
Previously the images were taken from the docker repository. However not everything from the images was needed and the current build for them is outdated (for example, the Debian/Jessie image for php-fpm was being used, instead of the current Debian/Stretch.

- **Chrome**
Install chrome and chromedriver, to be used in headless mode

- **Use root instead of app:app user**

- **Test scripts**
These scripts were designed to be used with Magento Plugins, expecting them to be symlinked and correctly configured before being used.